### PR TITLE
Fixes bug when passing boolean to '-so' argument

### DIFF
--- a/hanasitter.py
+++ b/hanasitter.py
@@ -1098,7 +1098,7 @@ def main():
     if '-lf' in sys.argv:
         log_features = sys.argv[sys.argv.index('-lf') + 1]
     if '-so' in sys.argv:
-        std_out = int(sys.argv[sys.argv.index('-so') + 1])
+        std_out = sys.argv[sys.argv.index('-so') + 1]
     if '-en' in sys.argv:
         receiver_emails = [x for x in sys.argv[  sys.argv.index('-en') + 1   ].split(',')] 
     if '-ens' in sys.argv:


### PR DESCRIPTION
Fixes exception when passing boolean values to '-so' argument:

Traceback (most recent call last):
  File "hanasitter.py", line 1537, in <module>
    main()
  File "hanasitter.py", line 1101, in main
    std_out = int(sys.argv[sys.argv.index('-so') + 1])
ValueError: invalid literal for int() with base 10: 'false'