### PR TITLE
fixing typo of recieverEmails which should be receiverEmails

### DIFF
--- a/hanasitter.py
+++ b/hanasitter.py
@@ -307,7 +307,7 @@ class EmailNotification:
             print("Mail Server: ", self.mailServer)
         else:
             print("Configured mail server will be used.")
-        print("Reciever Emails: ", self.receiverEmails)
+        print("Receiver Emails: ", self.receiverEmails)
 
 #### Remember:
 #Nameserver port is always 3**01 and SQL port = 3**13 valid for,

--- a/hanasitter.py
+++ b/hanasitter.py
@@ -307,7 +307,7 @@ class EmailNotification:
             print("Mail Server: ", self.mailServer)
         else:
             print("Configured mail server will be used.")
-        print("Reciever Emails: ", self.recieverEmails)
+        print("Reciever Emails: ", self.receiverEmails)
 
 #### Remember:
 #Nameserver port is always 3**01 and SQL port = 3**13 valid for,


### PR DESCRIPTION
The issue was found via pylint linter:
hanaSitter.py:685:35: E1101: Instance of 'EmailNotification' has no 'recieverEmails' member (no-member)